### PR TITLE
Fix: refresh datagrid after scraping (#3)

### DIFF
--- a/Xiaomi Software Manager/UI/Views/Windows/MainWindow.axaml.cs
+++ b/Xiaomi Software Manager/UI/Views/Windows/MainWindow.axaml.cs
@@ -404,6 +404,16 @@ public partial class MainWindow : Window
 			return;
 		}
 
+		var gridState = ViewModel.GetGridState();
+		var refreshedState = new SoftwareGridState
+		{
+			SearchText = string.Empty,
+			RegionAllSelected = gridState.RegionAllSelected,
+			SelectedRegions = gridState.SelectedRegions,
+			SortMemberPath = gridState.SortMemberPath,
+			SortDirection = gridState.SortDirection
+		};
+
 		Logger.Instance.Log("Refreshing local software list.");
 		ViewModel.IsRefreshingLocal = true;
 		try
@@ -413,6 +423,7 @@ public partial class MainWindow : Window
 			Logger.Instance.Log($"Local software scan completed. Updated {summary.Updated}/{summary.Total} entries.",
 				LogLevel.Info);
 			await LoadSoftwareAsync(ShutdownToken);
+			ViewModel.ApplyGridState(refreshedState);
 			await UpdateLocalStatsAsync();
 		}
 		catch (OperationCanceledException)

--- a/Xiaomi Software Manager/UI/Views/Windows/MainWindow.axaml.cs
+++ b/Xiaomi Software Manager/UI/Views/Windows/MainWindow.axaml.cs
@@ -342,6 +342,8 @@ public partial class MainWindow : Window
 				var dialog = new ScrapeIssuesDialog(issues);
 				await dialog.ShowDialog(this);
 			}
+
+			await LoadSoftwareAsync(ShutdownToken);
 		}
 		catch (OperationCanceledException)
 		{


### PR DESCRIPTION
Closes #3
Closes #4

Additional changes:
- On startup, the app now clears any persisted search text while keeping region filters and defaulting the grid sort to LocalVersion descending so locally available items appear first.